### PR TITLE
Update HomeContent.py

### DIFF
--- a/modules/Home/HomeContent.py
+++ b/modules/Home/HomeContent.py
@@ -15,7 +15,7 @@ from stingray.gti import get_gti_lengths, get_btis, get_total_gti_length
 
 # Dashboard Classes and Event Data Imports
 from utils.globals import loaded_event_data
-from utils.DashboardClasses import (
+from utils.dashboardClasses import (
     MainHeader,
     MainArea,
     OutputBox,


### PR DESCRIPTION

### updating home content.py in stringray explorer.
**Issue** : ModuleNotFoundError for utils.DashboardClasses in HomeContent.py

**Problem**: The error message encountered
ModuleNotFoundError: No module named 'utils.DashboardClasses'. This error occurs due to case sensitivity in Python import statements.

**Solution**: Corrected the import statement in HomeContent.py to use the correct case for DashboardClasses.py (i.e., dashboardClasses instead of DashboardClasses).

**Impact**: This fix resolves the ModuleNotFoundError by ensuring that the import statement matches the case-sensitive file naming convention in Python.
![Screenshot (237)](https://github.com/user-attachments/assets/65660dd3-8158-4a62-9bf8-24d149fd5acd)
